### PR TITLE
Add original file in output.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nationalarchives/file-information",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "scripts": {
         "test": "jest",
         "build": "webpack --mode development",
-	"lint": "eslint src/**/*.ts && eslint test/**/*.ts",
+        "lint": "eslint src/**/*.ts && eslint test/**/*.ts",
         "build:watch": "webpack --mode development --watch",
         "build:prod": "webpack --mode production"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nationalarchives/file-information",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "A library for getting file information.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,8 @@ export const extractFileMetadata: TFileMetadata = async (
       checksum,
       size,
       lastModified: new Date(lastModified),
-      path: (<TdrFile>file).webkitRelativePath
+      path: (<TdrFile>file).webkitRelativePath,
+      file
     })
     processedFiles += 1
     updateProgress(processedChunks, processedFiles)

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface IFileMetadata {
   size: number
   path: string
   lastModified: Date
+  file: File
 }
 
 export interface IProgressInformation {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -51,6 +51,14 @@ test("returns the correct path", async () => {
   expect(result[0].path).toEqual("/a/path")
 })
 
+test("returns the original file", async () => {
+  const blob = new Blob([new Uint8Array(fs.readFileSync("test/testfile"))])
+  const file = new File([blob], "")
+  Object.defineProperty(file, "webkitRelativePath", { value: "/a/path" })
+  const result = await extractFileMetadata([file])
+  expect(result[0].file).toEqual(file)
+})
+
 test("calls the callback function correctly", async () => {
   const blob = new Blob([new Uint8Array(fs.readFileSync("test/testfile"))])
   const file = new File([blob], "")


### PR DESCRIPTION
This makes it easier on the front end to work out which file belongs to
which metadata object.