### PR TITLE
Check condition to test for merge commit not npm version commit

### DIFF
--- a/Jenkinsfile-publish
+++ b/Jenkinsfile-publish
@@ -1,6 +1,7 @@
 library("tdr-jenkinslib")
 
 def versionBumpBranch = "version-bump-${BUILD_NUMBER}-${params.VERSION}"
+def pullRequestTitlePrefix = "Jenkins generated version bump from build number"
 
 pipeline {
   agent none
@@ -18,10 +19,10 @@ pipeline {
       when {
         //Only trigger version bump for non-version bump commits
         //Prevents infinite loop of creating pull requests for version bumps
-        //Npm version bump commits in format: 0.0.0
+        //Npm merge version bump commit messages in format: 'Jenkins generated version bump from build number 000'
         expression {
           currentGitCommit = sh(script: "git log -n 1", returnStdout: true).trim()
-          return !(currentGitCommit ==~ /(\d+)\.(\d+)\.(\d+)/)
+          return !(currentGitCommit =~ (currentGitCommit =~ /$pullRequestTitlePrefix (\d+)/))
         }
       }
       stages {
@@ -61,7 +62,7 @@ pipeline {
           steps {
             script {
               tdr.createGitHubPullRequest(
-                pullRequestTitle: "Version Bump from build number ${BUILD_NUMBER}",
+                pullRequestTitle: "${pullRequestTitlePrefix} ${BUILD_NUMBER}",
                 buildUrl: env.BUILD_URL,
                 repo: "tdr-file-metadata",
                 branchToMergeTo: "master",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nationalarchives/file-information",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "A library for getting file information.",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",


### PR DESCRIPTION
Should check for the merge request commit for the Jenkins generated pull request and not the npm version bump commit itself

Flow is:
1. Developer changes merged to master branch;
2. Npm version bump branch generated by Jenkinsfile-publish job;
3. Npm version bump script run by Jenkinsfile-publish job which commits npm version change with commit message in the format: '0.0.0';
4. Npm version bump commit merged to Jenkins generated version bump branch from step 2;
5. New pull request generated by Jenkinsfile-publish job with commit message in format: 'Jenkins generated version bump from build number 000'
6. Developer approves and merges Jenkins generated pull request
7. Conditional check looks at latest commit message, which will be the commit message from step 5, and prevents new branch and pull request from being generated
8. Flow starts again at step 1

Made the generated pull request commit message more specific to prevent a developer commit message matching and preventing the npm version bump cycle