### PR TITLE
Change the input to IFileWithPath

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,7 @@ export interface IProgressInformation {
 }
 
 export type TFileMetadata = (
-  files: File[],
+  files: IFileWithPath[],
   progressFunction?: TProgressFunction | undefined,
   chunkSize?: number
 ) => Promise<IFileMetadata[]>
@@ -26,7 +26,7 @@ export type TGenerateMetadata = (
   chunkProgressFunction: TChunkProgressFunction
 ) => Promise<string>
 
-export type TTotalChunks = (files: File[], chunkSize: number) => number
+export type TTotalChunks = (files: IFileWithPath[], chunkSize: number) => number
 
 export type TSliceToArray = (blob: Blob) => Promise<Uint8Array>
 
@@ -34,6 +34,7 @@ export type TProgressFunction = (
   progressInformation: IProgressInformation
 ) => void
 
-export interface TdrFile extends File {
-  webkitRelativePath: string
+export interface IFileWithPath {
+  file: File
+  path: string
 }


### PR DESCRIPTION
With the drag and drop, we can't populate the webkitRelativePath
parameter on File so we need a way of passing in the path to this
function which works for both the drag and drop and the normal file
input.