### PR TITLE
Update DtsBundle syntax

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
       crypto: false,
     },
   },
-  plugins: [],
+  plugins: [new DtsBundlePlugin()],
   output: {
     filename: "index.js",
     libraryTarget: "umd",
@@ -29,7 +29,7 @@ module.exports = {
 
 function DtsBundlePlugin() {}
 DtsBundlePlugin.prototype.apply = function (compiler) {
-  compiler.plugin("done", function () {
+  compiler.hooks.done.tap("bundle-types", () => {
     var dts = require("dts-bundle")
 
     dts.bundle({


### PR DESCRIPTION
Compiler function syntax changed in Webpack version 4.

See following blog: https://medium.com/@sheng_di/webpack-4-migration-notes-65f2f4b79b8f

Typescript type file was not getting generated in the dist folder