### PR TITLE
Manually bump jest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "url": "https://github.com/nationalarchives/tdr-file-information"
     },
     "devDependencies": {
-        "@types/jest": "^26.0.19",
+        "@types/jest": "^26.0.22",
         "@typescript-eslint/eslint-plugin": "^2.23.0",
         "@typescript-eslint/parser": "^2.23.0",
         "dts-bundle": "^0.7.3",
@@ -36,10 +36,10 @@
         "eslint-plugin-jest": "^24.1.3",
         "eslint-plugin-prettier": "^3.1.2",
         "husky": "^6.0.0",
-        "jest": "^25.1.0",
+        "jest": "^25.5.4",
         "lint-staged": "^10.0.8",
         "prettier": "2.2.1",
-        "ts-jest": "^25.2.1",
+        "ts-jest": "^25.5.1",
         "ts-loader": "^9.0.0",
         "typescript": "^3.8.3",
         "webpack": "^5.10.3",


### PR DESCRIPTION
package.json and package-lock.json jest version are out of sync.

package-lock.json versions are up to date.

package.json versions manually updated to match package-lock.json versions