### PR TITLE
Don't use inline source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,6 @@ const fs = require("fs")
 
 module.exports = {
   entry: "./src/index.ts",
-  devtool: "inline-source-map",
   module: {
     rules: [
       {


### PR DESCRIPTION
With them, the bundle is 1.12M, without, it's around 150K. We can add
them back if we desperately miss them.
