### PR TITLE
Merge declaration files.

### DIFF
--- a/.github/scripts/deploy_npm.sh
+++ b/.github/scripts/deploy_npm.sh
@@ -5,7 +5,7 @@ git checkout -b $BRANCH_NAME
 git push -u origin $BRANCH_NAME
 npm config set //registry.npmjs.org/:_authToken=$1
 npm ci
-npm run build
+npm run build:prod
 npm version patch
 git add package.json package-lock.json
 git commit -m 'Update npm version'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "webpack --mode development",
     "lint": "eslint src/**/*.ts && eslint test/**/*.ts",
     "build:watch": "webpack --mode development --watch",
-    "build:prod": "webpack --mode production"
+    "build:prod": "webpack --mode production && cat dist/types.d.ts >> dist/index.d.ts && rm dist/types.d.ts"
   },
   "author": "The National Archives TDR Team",
   "license": "MIT",


### PR DESCRIPTION
We were using dts-bundler to merge the two typescript declaration files
into one which is how the front end needs it.

dst-bundler is not maintained and more or less every dependency had a
CVE against it. Most of the other typescript bundlers haven't been
touched in years either.

All we need to do is merge the two files. This is quick and dirty but it
does work and it saves us having to install a new dependency to do the
job for us. I've tested this locally and it does work with the frontend.
